### PR TITLE
Modify img path access

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,4 +4,4 @@ var tube = pictureTube({cols: 65});
 tube.pipe(process.stdout);
 
 var fs = require('fs');
-fs.createReadStream('img/ymzkmct.png').pipe(tube);
+fs.createReadStream(__dirname + '/img/ymzkmct.png').pipe(tube);


### PR DESCRIPTION
自分の環境だと、下のエラーが出てしまって、`__dirname` を path の前に足すとうまくいくようでした。勘違いだったらすみません :sweat_smile: 

```
$ npm install -g ymzkmct
/Users/kt3k/.nvm/v0.10.29/bin/ymzkmct -> /Users/kt3k/.nvm/v0.10.29/lib/node_modules/ymzkmct/index.js
ymzkmct@0.0.1 /Users/kt3k/.nvm/v0.10.29/lib/node_modules/ymzkmct
└── picture-tube@0.0.4 (buffers@0.1.1, x256@0.0.2, charm@0.1.2, request@2.9.203, optimist@0.3.7, event-stream@0.9.8, png-js@0.1.1)
$ node --version
v0.10.29
$ npm --version
1.4.14
$ ymzkmct

events.js:72
        throw er; // Unhandled 'error' event
              ^
Error: ENOENT, open 'img/ymzkmct.png'
```
